### PR TITLE
remove reminders

### DIFF
--- a/src/screens/ConnectionsView.js
+++ b/src/screens/ConnectionsView.js
@@ -372,22 +372,6 @@ function ConnectionsView(props) {
                       </View>
                       <Text style={styles.iconLabel}>LOG EMAIL</Text>
                     </View>
-
-                    <View style={styles.iconLabelContainer}>
-                      <View style={styles.iconContainer}>
-                        <TouchableOpacity
-                          onPress={async () => {
-                            passEngagementType('R')
-                          }}
-                        >
-                          <MaterialCommunityIcons
-                            name='reminder'
-                            style={styles.iconStyles}
-                          />
-                        </TouchableOpacity>
-                      </View>
-                      <Text style={styles.iconLabel}>REMINDER</Text>
-                    </View>
                   </View>
 
                   <View>

--- a/src/store/actions/connectionData.js
+++ b/src/store/actions/connectionData.js
@@ -37,7 +37,8 @@ export const getEngagements = (id) => dispatch => {
 
                     dispatch({
                         type: GET_ENGAGEMENTS_SUCCESS,
-                        payload: res.data.results
+                        // filter out Reminders as they are not properly implemented yet
+                        payload: res.data.results.filter(engagement => engagement.data_type !== 'R')
                     });
                 })
                 .catch(err => {


### PR DESCRIPTION
Reminders were never fully implemented so they are being removed until such time as they are implemented properly.

This PR filters reminders from being shown in the engagements view and removes the button to add new reminders.

<img width="491" alt="Screenshot 2020-01-14 16 43 52" src="https://user-images.githubusercontent.com/396620/72385324-3e624c80-36ed-11ea-99ef-e85c4ea3bf67.png">
