### PR TITLE
create AddDocumentButtonsGroup

### DIFF
--- a/src/components/ConnectionsViewTabs/AddDocForm.tsx
+++ b/src/components/ConnectionsViewTabs/AddDocForm.tsx
@@ -237,7 +237,8 @@ const AddDocForm = (props) => {
                             alignItems: 'flex-start',
                         }}
                     >
-                        <View
+                        {/* STAKEHOLDER HAS REQUESTED THE CODE BELOW BE PRESERVERED FOR FUTURE USE */}
+                        {/* <View
                             style={{
                                 flexDirection: 'row',
                                 width: '100%',
@@ -273,7 +274,7 @@ const AddDocForm = (props) => {
                                     onPress={() => setIsPublic(!isPublic)}
                                 />
                             </View>
-                        </View>
+                        </View> */}
                         <View style={{ width: '100%' }}>
                             <View style={{ width: '100%', alignItems: 'flex-end', marginTop: 20 }}>
                                 <TouchableOpacity

--- a/src/components/ConnectionsViewTabs/AddDocForm.tsx
+++ b/src/components/ConnectionsViewTabs/AddDocForm.tsx
@@ -12,7 +12,7 @@ import {
     Picker,
 } from 'react-native';
 import SwitchToggle from 'react-native-switch-toggle';
-import { Feather } from '@expo/vector-icons';
+import { Feather, AntDesign, Ionicons, MaterialCommunityIcons } from '@expo/vector-icons';
 import { getEngagements } from '../../store/actions/connectionData';
 import constants from '../../helpers/constants';
 import { connect } from 'react-redux';
@@ -20,7 +20,7 @@ import { postConnectionDocument } from '../../store/actions/connectionEngagement
 import * as ImagePicker from 'expo-image-picker';
 import * as Permissions from 'expo-permissions';
 import Constants from 'expo-constants';
-import { AntDesign, Ionicons, MaterialCommunityIcons } from '@expo/vector-icons';
+
 import RNPickerSelect from 'react-native-picker-select';
 
 const AddDocForm = (props) => {
@@ -282,6 +282,7 @@ const AddDocForm = (props) => {
                                         props.postConnectionDocument(props.navigation.getParam('id'), title, category, isPublic, notes, attachment);
                                         props.navigation.goBack();
                                     }}
+                                    // Needs to pass file URI as attachment above
                                 >
                                     <Text style={styles.buttonText}>SAVE</Text>
                                 </TouchableOpacity>

--- a/src/components/ConnectionsViewTabs/AddDocForm.tsx
+++ b/src/components/ConnectionsViewTabs/AddDocForm.tsx
@@ -279,10 +279,9 @@ const AddDocForm = (props) => {
                                 <TouchableOpacity
                                     style={styles.saveButton}
                                     onPress={() => {
-                                        props.postConnectionDocument(props.navigation.getParam('id'), title, category, isPublic, notes, attachment);
+                                        props.postConnectionDocument(props.navigation.getParam('id'), title, category, isPublic, notes, props.navigation.getParam('uri'));
                                         props.navigation.goBack();
                                     }}
-                                    // Needs to pass file URI as attachment above
                                 >
                                     <Text style={styles.buttonText}>SAVE</Text>
                                 </TouchableOpacity>

--- a/src/components/ConnectionsViewTabs/AddDocForm.tsx
+++ b/src/components/ConnectionsViewTabs/AddDocForm.tsx
@@ -199,36 +199,6 @@ const AddDocForm = (props) => {
                             enablesReturnKeyAutomatically
                         />
                     </View>
-                    <View style={{ width: '95%' }}>
-                        <TouchableOpacity
-                            style={{ width: '50%' }}
-                            onPress={() => {
-                                _pickImage();
-                            }}
-                        >
-                            <Text style={{ fontSize: 15 }}>SELECT AN IMAGE</Text>
-                            {attachment
-                                ? <Image
-                                    source={{ uri: attachment }}
-                                    alt={title}
-                                    style={{
-                                        width: 125,
-                                        height: 125,
-                                        marginBottom: 4,
-                                        marginTop: 4,
-                                    }}
-                                />
-                                : <MaterialCommunityIcons
-                                    name="image-plus"
-                                    size={75}
-                                    color={constants.highlightColor}
-                                    // onPress={() => {
-                                    //   props.closeForm()
-                                    // }}
-                                />
-                            }
-                        </TouchableOpacity>
-                    </View>
                     <View
                         style={{
                             width: '95%',

--- a/src/components/ConnectionsViewTabs/AddDocumentButtonsGroup/Button.jsx
+++ b/src/components/ConnectionsViewTabs/AddDocumentButtonsGroup/Button.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { TouchableOpacity } from 'react-native';
+import styles from './styles.js';
+
+/**********************************************************/
+
+export default function Button({ onPress, children }) {
+    return (
+        <TouchableOpacity
+            style={styles.button}
+            onPress={onPress}
+        >
+            {children}
+        </TouchableOpacity>
+    );
+}

--- a/src/components/ConnectionsViewTabs/AddDocumentButtonsGroup/PickFileButton.jsx
+++ b/src/components/ConnectionsViewTabs/AddDocumentButtonsGroup/PickFileButton.jsx
@@ -1,13 +1,29 @@
 import React from 'react';
 import Button from './Button.jsx';
 import PickFileIcon from './PickFileIcon.jsx';
+import * as DocumentPicker from 'expo-document-picker';
 
 /**********************************************************/
 
 export default function PickFileButton({ setDocument }) {
 
     function pickFile() {
-        return;
+        DocumentPicker
+            .getDocumentAsync({
+                /* MIME type */
+                type: '*/*',
+                /* whether to cache file for other expo APIs to use */
+                copyToCacheDirectory: false,
+                /* whether to let user select multiple files */
+                multiple: false,
+            })
+            .then ((re) => {
+                setDocument(re);
+            })
+            .catch ((error) => {
+                console.error('--- There was a problem selecting a file. ---');
+                console.log(error);
+            });
     }
 
     return (

--- a/src/components/ConnectionsViewTabs/AddDocumentButtonsGroup/PickFileButton.jsx
+++ b/src/components/ConnectionsViewTabs/AddDocumentButtonsGroup/PickFileButton.jsx
@@ -11,7 +11,7 @@ export default function PickFileButton({ setDocument }) {
         DocumentPicker
             .getDocumentAsync({
                 /* MIME type */
-                type: '*/*',
+                type: 'application/*',
                 /* whether to cache file for other expo APIs to use */
                 copyToCacheDirectory: false,
                 /* whether to let user select multiple files */

--- a/src/components/ConnectionsViewTabs/AddDocumentButtonsGroup/PickFileButton.jsx
+++ b/src/components/ConnectionsViewTabs/AddDocumentButtonsGroup/PickFileButton.jsx
@@ -4,7 +4,7 @@ import PickFileIcon from './PickFileIcon.jsx';
 
 /**********************************************************/
 
-export default function PickFileButton() {
+export default function PickFileButton({ setDocument }) {
 
     function pickFile() {
         return;

--- a/src/components/ConnectionsViewTabs/AddDocumentButtonsGroup/PickFileButton.jsx
+++ b/src/components/ConnectionsViewTabs/AddDocumentButtonsGroup/PickFileButton.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import Button from './Button.jsx';
+import PickFileIcon from './PickFileIcon.jsx';
+
+/**********************************************************/
+
+export default function PickFileButton() {
+
+    function pickFile() {
+        return;
+    }
+
+    return (
+        <Button onPress={pickFile}>
+            <PickFileIcon/>
+        </Button>
+    );
+}

--- a/src/components/ConnectionsViewTabs/AddDocumentButtonsGroup/PickFileButton.jsx
+++ b/src/components/ConnectionsViewTabs/AddDocumentButtonsGroup/PickFileButton.jsx
@@ -5,7 +5,7 @@ import * as DocumentPicker from 'expo-document-picker';
 
 /**********************************************************/
 
-export default function PickFileButton({ setDocument }) {
+export default function PickFileButton({ afterAccept }) {
 
     function pickFile() {
         DocumentPicker
@@ -18,7 +18,9 @@ export default function PickFileButton({ setDocument }) {
                 multiple: false,
             })
             .then ((re) => {
-                setDocument(re);
+                if (re.type === 'success') {
+                    afterAccept(re.uri);
+                }
             })
             .catch ((error) => {
                 console.error('--- There was a problem selecting a file. ---');

--- a/src/components/ConnectionsViewTabs/AddDocumentButtonsGroup/PickFileIcon.jsx
+++ b/src/components/ConnectionsViewTabs/AddDocumentButtonsGroup/PickFileIcon.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { MaterialIcons } from '@expo/vector-icons';
+import icons from './icons.js';
+
+/**********************************************************/
+
+export default function PickFileIcon({
+    color = icons.color,
+    size = icons.size,
+}) {
+    return (
+        <MaterialIcons
+            name={'insert-drive-file'}
+            size={size}
+            color={color}
+        />
+    );
+}

--- a/src/components/ConnectionsViewTabs/AddDocumentButtonsGroup/PickPhotoButton.jsx
+++ b/src/components/ConnectionsViewTabs/AddDocumentButtonsGroup/PickPhotoButton.jsx
@@ -1,12 +1,22 @@
 import React from 'react';
 import Button from './Button.jsx';
 import PickPhotoIcon from './PickPhotoIcon.jsx';
+import * as ImagePicker from 'expo-image-picker';
 
 /**********************************************************/
 
 export default function PickPhotoButton({ setDocument }) {
 
-    function pickPhoto() {
+    async function pickPhoto() {
+        const result = await ImagePicker.launchImageLibraryAsync({
+            mediaTypes: ImagePicker.MediaTypeOptions.Images,
+            allowsEditing: false,
+        });
+
+        if (!result.cancelled) {
+            setDocument(result.uri);
+        }
+
         return;
     }
 

--- a/src/components/ConnectionsViewTabs/AddDocumentButtonsGroup/PickPhotoButton.jsx
+++ b/src/components/ConnectionsViewTabs/AddDocumentButtonsGroup/PickPhotoButton.jsx
@@ -4,7 +4,7 @@ import PickPhotoIcon from './PickPhotoIcon.jsx';
 
 /**********************************************************/
 
-export default function PickPhotoButton() {
+export default function PickPhotoButton({ setDocument }) {
 
     function pickPhoto() {
         return;

--- a/src/components/ConnectionsViewTabs/AddDocumentButtonsGroup/PickPhotoButton.jsx
+++ b/src/components/ConnectionsViewTabs/AddDocumentButtonsGroup/PickPhotoButton.jsx
@@ -32,8 +32,18 @@ export default function PickPhotoButton({ setDocument }) {
         return;
     }
 
+    async function onPress() {
+        const hasPermissions = await getPermissions();
+        if (hasPermissions) {
+            await pickPhoto();
+        }
+        else {
+            Alert.alert('Sorry, we need camera roll permissions to make this work!');
+        }
+    }
+
     return (
-        <Button onPress={pickPhoto}>
+        <Button onPress={onPress}>
             <PickPhotoIcon/>
         </Button>
     );

--- a/src/components/ConnectionsViewTabs/AddDocumentButtonsGroup/PickPhotoButton.jsx
+++ b/src/components/ConnectionsViewTabs/AddDocumentButtonsGroup/PickPhotoButton.jsx
@@ -13,7 +13,7 @@ export default function PickPhotoButton({ setDocument }) {
     async function getPermissions() {
         let hasPermissions = false;
         if (Constants.platform.ios || Constants.platform.android) {
-            const { status } = await Permissions.askAsync(Permissions.CAMERA_ROLL || Permissions.CAMERA);
+            const { status } = await Permissions.askAsync(Permissions.CAMERA_ROLL);
             hasPermissions = status === 'granted';
         }
         return hasPermissions;

--- a/src/components/ConnectionsViewTabs/AddDocumentButtonsGroup/PickPhotoButton.jsx
+++ b/src/components/ConnectionsViewTabs/AddDocumentButtonsGroup/PickPhotoButton.jsx
@@ -1,11 +1,23 @@
 import React from 'react';
 import Button from './Button.jsx';
+import { Alert } from 'react-native';
 import PickPhotoIcon from './PickPhotoIcon.jsx';
 import * as ImagePicker from 'expo-image-picker';
+import * as Permissions from 'expo-permissions';
+import Constants from 'expo-constants';
 
 /**********************************************************/
 
 export default function PickPhotoButton({ setDocument }) {
+
+    async function getPermissions() {
+        let hasPermissions = false;
+        if (Constants.platform.ios || Constants.platform.android) {
+            const { status } = await Permissions.askAsync(Permissions.CAMERA_ROLL || Permissions.CAMERA);
+            hasPermissions = status === 'granted';
+        }
+        return hasPermissions;
+    }
 
     async function pickPhoto() {
         const result = await ImagePicker.launchImageLibraryAsync({

--- a/src/components/ConnectionsViewTabs/AddDocumentButtonsGroup/PickPhotoButton.jsx
+++ b/src/components/ConnectionsViewTabs/AddDocumentButtonsGroup/PickPhotoButton.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import Button from './Button.jsx';
+import PickPhotoIcon from './PickPhotoIcon.jsx';
+
+/**********************************************************/
+
+export default function PickPhotoButton() {
+
+    function pickPhoto() {
+        return;
+    }
+
+    return (
+        <Button onPress={pickPhoto}>
+            <PickPhotoIcon/>
+        </Button>
+    );
+}

--- a/src/components/ConnectionsViewTabs/AddDocumentButtonsGroup/PickPhotoButton.jsx
+++ b/src/components/ConnectionsViewTabs/AddDocumentButtonsGroup/PickPhotoButton.jsx
@@ -8,7 +8,7 @@ import Constants from 'expo-constants';
 
 /**********************************************************/
 
-export default function PickPhotoButton({ setDocument }) {
+export default function PickPhotoButton({ afterAccept }) {
 
     async function getPermissions() {
         let hasPermissions = false;
@@ -26,7 +26,7 @@ export default function PickPhotoButton({ setDocument }) {
         });
 
         if (!result.cancelled) {
-            setDocument(result.uri);
+            afterAccept(result.uri);
         }
 
         return;

--- a/src/components/ConnectionsViewTabs/AddDocumentButtonsGroup/PickPhotoIcon.jsx
+++ b/src/components/ConnectionsViewTabs/AddDocumentButtonsGroup/PickPhotoIcon.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { MaterialIcons } from '@expo/vector-icons';
+import icons from './icons.js';
+
+/**********************************************************/
+
+export default function PickPhotoIcon({
+    color = icons.color,
+    size = icons.size,
+}) {
+    return (
+        <MaterialIcons
+            name={'photo-library'}
+            size={size}
+            color={color}
+        />
+    );
+}

--- a/src/components/ConnectionsViewTabs/AddDocumentButtonsGroup/TakePhotoButton.jsx
+++ b/src/components/ConnectionsViewTabs/AddDocumentButtonsGroup/TakePhotoButton.jsx
@@ -1,6 +1,10 @@
 import React from 'react';
+import { Alert } from 'react-native';
 import Button from './Button.jsx';
 import TakePhotoIcon from './TakePhotoIcon.jsx';
+import * as ImagePicker from 'expo-image-picker';
+import * as Permissions from 'expo-permissions';
+import Constants from 'expo-constants';
 
 /**********************************************************/
 

--- a/src/components/ConnectionsViewTabs/AddDocumentButtonsGroup/TakePhotoButton.jsx
+++ b/src/components/ConnectionsViewTabs/AddDocumentButtonsGroup/TakePhotoButton.jsx
@@ -10,14 +10,12 @@ import Constants from 'expo-constants';
 
 export default function TakePhotoButton({ setDocument }) {
 
+
     async function getPermissions() {
         let hasPermissions = false;
         if (Constants.platform.ios || Constants.platform.android) {
             const { status } = await Permissions.askAsync(Permissions.CAMERA_ROLL || Permissions.CAMERA);
             hasPermissions = status === 'granted';
-            if (!hasPermissions) {
-                Alert.alert('Sorry, we need camera roll permissions to make this work!');
-            }
         }
         return hasPermissions;
     }
@@ -35,8 +33,18 @@ export default function TakePhotoButton({ setDocument }) {
         return;
     }
 
+    async function onPress() {
+        const hasPermissions = await getPermissions();
+        if (hasPermissions) {
+            await takePhoto();
+        }
+        else {
+            Alert.alert('Sorry, we need camera roll permissions to make this work!');
+        }
+    }
+
     return (
-        <Button onPress={takePhoto}>
+        <Button onPress={onPress}>
             <TakePhotoIcon/>
         </Button>
     );

--- a/src/components/ConnectionsViewTabs/AddDocumentButtonsGroup/TakePhotoButton.jsx
+++ b/src/components/ConnectionsViewTabs/AddDocumentButtonsGroup/TakePhotoButton.jsx
@@ -6,13 +6,16 @@ import TakePhotoIcon from './TakePhotoIcon.jsx';
 
 export default function TakePhotoButton({ setDocument }) {
 
+
    async function getPermissions(){
-    if (Constants.platform.ios || Constants.platform.android) {
-        const { status } = await Permissions.askAsync(Permissions.CAMERA_ROLL || Permissions.CAMERA);
-        if (status !== 'granted') {
-            Alert.alert('Sorry, we need camera roll permissions to make this work!');
+        if (Constants.platform.ios || Constants.platform.android) {
+            const { status } = await Permissions.askAsync(Permissions.CAMERA_ROLL || Permissions.CAMERA);
+            const hasPermission = status === 'granted';
+            if (!hasPermission) {
+                Alert.alert('Sorry, we need camera roll permissions to make this work!');
+            }
         }
-     }
+        return hasPermission;
     }
 
     async function takePhoto() {

--- a/src/components/ConnectionsViewTabs/AddDocumentButtonsGroup/TakePhotoButton.jsx
+++ b/src/components/ConnectionsViewTabs/AddDocumentButtonsGroup/TakePhotoButton.jsx
@@ -6,7 +6,16 @@ import TakePhotoIcon from './TakePhotoIcon.jsx';
 
 export default function TakePhotoButton({ setDocument }) {
 
-    function takePhoto() {
+    async function takePhoto() {
+        const result = await ImagePicker.launchCameraAsync({
+            mediaTypes: ImagePicker.MediaTypeOptions.Images,
+            allowsEditing: false,
+        });
+
+        if (!result.cancelled) {
+            setDocument(result.uri);
+        }
+
         return;
     }
 

--- a/src/components/ConnectionsViewTabs/AddDocumentButtonsGroup/TakePhotoButton.jsx
+++ b/src/components/ConnectionsViewTabs/AddDocumentButtonsGroup/TakePhotoButton.jsx
@@ -4,7 +4,7 @@ import TakePhotoIcon from './TakePhotoIcon.jsx';
 
 /**********************************************************/
 
-export default function TakePhotoButton() {
+export default function TakePhotoButton({ setDocument }) {
 
     function takePhoto() {
         return;

--- a/src/components/ConnectionsViewTabs/AddDocumentButtonsGroup/TakePhotoButton.jsx
+++ b/src/components/ConnectionsViewTabs/AddDocumentButtonsGroup/TakePhotoButton.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import Button from './Button.jsx';
+import TakePhotoIcon from './TakePhotoIcon.jsx';
+
+/**********************************************************/
+
+export default function TakePhotoButton() {
+
+    function takePhoto() {
+        return;
+    }
+
+    return (
+        <Button onPress={takePhoto}>
+            <TakePhotoIcon/>
+        </Button>
+    );
+}

--- a/src/components/ConnectionsViewTabs/AddDocumentButtonsGroup/TakePhotoButton.jsx
+++ b/src/components/ConnectionsViewTabs/AddDocumentButtonsGroup/TakePhotoButton.jsx
@@ -6,6 +6,15 @@ import TakePhotoIcon from './TakePhotoIcon.jsx';
 
 export default function TakePhotoButton({ setDocument }) {
 
+   async function getPermissions(){
+    if (Constants.platform.ios || Constants.platform.android) {
+        const { status } = await Permissions.askAsync(Permissions.CAMERA_ROLL || Permissions.CAMERA);
+        if (status !== 'granted') {
+            Alert.alert('Sorry, we need camera roll permissions to make this work!');
+        }
+     }
+    }
+
     async function takePhoto() {
         const result = await ImagePicker.launchCameraAsync({
             mediaTypes: ImagePicker.MediaTypeOptions.Images,

--- a/src/components/ConnectionsViewTabs/AddDocumentButtonsGroup/TakePhotoButton.jsx
+++ b/src/components/ConnectionsViewTabs/AddDocumentButtonsGroup/TakePhotoButton.jsx
@@ -8,7 +8,7 @@ import Constants from 'expo-constants';
 
 /**********************************************************/
 
-export default function TakePhotoButton({ setDocument }) {
+export default function TakePhotoButton({ afterAccept }) {
 
 
     async function getPermissions() {
@@ -27,7 +27,7 @@ export default function TakePhotoButton({ setDocument }) {
         });
 
         if (!result.cancelled) {
-            setDocument(result.uri);
+            afterAccept(result.uri);
         }
 
         return;

--- a/src/components/ConnectionsViewTabs/AddDocumentButtonsGroup/TakePhotoButton.jsx
+++ b/src/components/ConnectionsViewTabs/AddDocumentButtonsGroup/TakePhotoButton.jsx
@@ -14,7 +14,7 @@ export default function TakePhotoButton({ setDocument }) {
     async function getPermissions() {
         let hasPermissions = false;
         if (Constants.platform.ios || Constants.platform.android) {
-            const { status } = await Permissions.askAsync(Permissions.CAMERA_ROLL || Permissions.CAMERA);
+            const { status } = await Permissions.askAsync(Permissions.CAMERA);
             hasPermissions = status === 'granted';
         }
         return hasPermissions;
@@ -39,7 +39,7 @@ export default function TakePhotoButton({ setDocument }) {
             await takePhoto();
         }
         else {
-            Alert.alert('Sorry, we need camera roll permissions to make this work!');
+            Alert.alert('Sorry, we need camera permissions to make this work!');
         }
     }
 

--- a/src/components/ConnectionsViewTabs/AddDocumentButtonsGroup/TakePhotoButton.jsx
+++ b/src/components/ConnectionsViewTabs/AddDocumentButtonsGroup/TakePhotoButton.jsx
@@ -6,16 +6,16 @@ import TakePhotoIcon from './TakePhotoIcon.jsx';
 
 export default function TakePhotoButton({ setDocument }) {
 
-
-   async function getPermissions(){
+    async function getPermissions() {
+        let hasPermissions = false;
         if (Constants.platform.ios || Constants.platform.android) {
             const { status } = await Permissions.askAsync(Permissions.CAMERA_ROLL || Permissions.CAMERA);
-            const hasPermission = status === 'granted';
-            if (!hasPermission) {
+            hasPermissions = status === 'granted';
+            if (!hasPermissions) {
                 Alert.alert('Sorry, we need camera roll permissions to make this work!');
             }
         }
-        return hasPermission;
+        return hasPermissions;
     }
 
     async function takePhoto() {

--- a/src/components/ConnectionsViewTabs/AddDocumentButtonsGroup/TakePhotoIcon.jsx
+++ b/src/components/ConnectionsViewTabs/AddDocumentButtonsGroup/TakePhotoIcon.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { MaterialIcons } from '@expo/vector-icons';
+import icons from './icons.js';
+
+/**********************************************************/
+
+export default function TakePhotoIcon({
+    color = icons.color,
+    size = icons.size,
+}) {
+    return (
+        <MaterialIcons
+            name={'photo-camera'}
+            size={size}
+            color={color}
+        />
+    );
+}

--- a/src/components/ConnectionsViewTabs/AddDocumentButtonsGroup/icons.js
+++ b/src/components/ConnectionsViewTabs/AddDocumentButtonsGroup/icons.js
@@ -1,0 +1,6 @@
+import constants from '../../../helpers/constants';
+
+export default {
+    color: constants.highlightColor,
+    size: 75,
+};

--- a/src/components/ConnectionsViewTabs/AddDocumentButtonsGroup/icons.js
+++ b/src/components/ConnectionsViewTabs/AddDocumentButtonsGroup/icons.js
@@ -1,6 +1,6 @@
 import constants from '../../../helpers/constants';
 
 export default {
-    color: constants.highlightColor,
-    size: 75,
+    color: constants.iconColor,
+    size: 50,
 };

--- a/src/components/ConnectionsViewTabs/AddDocumentButtonsGroup/index.jsx
+++ b/src/components/ConnectionsViewTabs/AddDocumentButtonsGroup/index.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { View } from 'react-native';
 import PickFileButton from './PickFileButton.jsx';
 import PickPhotoButton from './PickPhotoButton.jsx';
@@ -8,14 +8,11 @@ import styles from './styles.js';
 /**********************************************************/
 
 export default function AddDocumentButtonsGroup({ afterAccept }) {
-
-    const [ document, setDocument ] = useState(null);
-
     return (
         <View style={styles.buttonsGroup}>
-            <PickFileButton setDocument={setDocument} afterAccept={afterAccept}/>
-            <PickPhotoButton setDocument={setDocument} afterAccept={afterAccept}/>
-            <TakePhotoButton setDocument={setDocument} afterAccept={afterAccept}/>
+            <PickFileButton afterAccept={afterAccept}/>
+            <PickPhotoButton afterAccept={afterAccept}/>
+            <TakePhotoButton afterAccept={afterAccept}/>
         </View>
     );
 }

--- a/src/components/ConnectionsViewTabs/AddDocumentButtonsGroup/index.jsx
+++ b/src/components/ConnectionsViewTabs/AddDocumentButtonsGroup/index.jsx
@@ -3,6 +3,7 @@ import { View } from 'react-native';
 import PickFileButton from './PickFileButton.jsx';
 import PickPhotoButton from './PickPhotoButton.jsx';
 import TakePhotoButton from './TakePhotoButton.jsx';
+import styles from './styles.js';
 
 /**********************************************************/
 
@@ -11,7 +12,7 @@ export default function AddDocumentButtonsGroup(props) {
     const [ document, setDocument ] = useState(null);
 
     return (
-        <View>
+        <View style={styles.buttonsGroup}>
             <PickFileButton setDocument={setDocument} />
             <PickPhotoButton setDocument={setDocument} />
             <TakePhotoButton setDocument={setDocument} />

--- a/src/components/ConnectionsViewTabs/AddDocumentButtonsGroup/index.jsx
+++ b/src/components/ConnectionsViewTabs/AddDocumentButtonsGroup/index.jsx
@@ -12,9 +12,9 @@ export default function AddDocumentButtonsGroup(props) {
 
     return (
         <View>
-            <PickFileButton/>
-            <PickPhotoButton/>
-            <TakePhotoButton/>
+            <PickFileButton setDocument={setDocument} />
+            <PickPhotoButton setDocument={setDocument} />
+            <TakePhotoButton setDocument={setDocument} />
         </View>
     );
 }

--- a/src/components/ConnectionsViewTabs/AddDocumentButtonsGroup/index.jsx
+++ b/src/components/ConnectionsViewTabs/AddDocumentButtonsGroup/index.jsx
@@ -28,7 +28,7 @@ export default function AddDocumentButtonsGroup(props) {
     return (
         <View>
             <Button
-                iconName={'file'}
+                iconName={'insert-drive-file'}
                 onPress={pickFile}
             />
             <Button

--- a/src/components/ConnectionsViewTabs/AddDocumentButtonsGroup/index.jsx
+++ b/src/components/ConnectionsViewTabs/AddDocumentButtonsGroup/index.jsx
@@ -1,0 +1,77 @@
+import React, { useState, useEffect } from 'react';
+import {
+    Text,
+    View,
+    TouchableOpacity,
+    StyleSheet,
+    Alert,
+} from 'react-native';
+import { MaterialIcons } from '@expo/vector-icons';
+import constants from '../../../helpers/constants';
+
+/**********************************************************/
+
+export default function AddDocumentButtonsGroup(props) {
+
+    const [ document, setDocuement ] = useState(null);
+
+    function pickFile() {
+        return;
+    }
+    function pickPhoto() {
+        return;
+    }
+    function takePhoto() {
+        return;
+    }
+
+    return (
+        <View>
+            <Button
+                iconName={'file'}
+                onPress={pickFile}
+            />
+            <Button
+                iconName={'photo-library'}
+                onPress={pickPhoto}
+            />
+            <Button
+                iconName={'photo-camera'}
+                onPress={takePhoto}
+            />
+        </View>
+    );
+}
+
+function Button({ onPress, iconName, ...rest }) {
+    return (
+        <TouchableOpacity
+            style={styles.imageButton}
+            onPress={onPress}
+        >
+            <MaterialIcons
+                name={iconName}
+                size={75}
+                color={constants.highlightColor}
+            />
+        </TouchableOpacity>
+    );
+}
+
+const styles = StyleSheet.create({
+    viewportContainer: {
+        width: '100%',
+        height: '100%',
+        justifyContent: 'flex-start',
+        borderRadius: 4,
+    },
+    image: {
+        width: 125,
+        height: 125,
+        marginBottom: 4,
+        marginTop: 4,
+    },
+    buttonImageContainer: { width: '95%' },
+    imageButton: { width: '50%' },
+
+});

--- a/src/components/ConnectionsViewTabs/AddDocumentButtonsGroup/index.jsx
+++ b/src/components/ConnectionsViewTabs/AddDocumentButtonsGroup/index.jsx
@@ -7,15 +7,15 @@ import styles from './styles.js';
 
 /**********************************************************/
 
-export default function AddDocumentButtonsGroup(props) {
+export default function AddDocumentButtonsGroup({ afterAccept }) {
 
     const [ document, setDocument ] = useState(null);
 
     return (
         <View style={styles.buttonsGroup}>
-            <PickFileButton setDocument={setDocument} />
-            <PickPhotoButton setDocument={setDocument} />
-            <TakePhotoButton setDocument={setDocument} />
+            <PickFileButton setDocument={setDocument} afterAccept={afterAccept}/>
+            <PickPhotoButton setDocument={setDocument} afterAccept={afterAccept}/>
+            <TakePhotoButton setDocument={setDocument} afterAccept={afterAccept}/>
         </View>
     );
 }

--- a/src/components/ConnectionsViewTabs/AddDocumentButtonsGroup/index.jsx
+++ b/src/components/ConnectionsViewTabs/AddDocumentButtonsGroup/index.jsx
@@ -13,7 +13,7 @@ import constants from '../../../helpers/constants';
 
 export default function AddDocumentButtonsGroup(props) {
 
-    const [ document, setDocuement ] = useState(null);
+    const [ document, setDocument ] = useState(null);
 
     function pickFile() {
         return;

--- a/src/components/ConnectionsViewTabs/AddDocumentButtonsGroup/index.jsx
+++ b/src/components/ConnectionsViewTabs/AddDocumentButtonsGroup/index.jsx
@@ -1,13 +1,8 @@
 import React, { useState, useEffect } from 'react';
-import {
-    Text,
-    View,
-    TouchableOpacity,
-    StyleSheet,
-    Alert,
-} from 'react-native';
-import { MaterialIcons } from '@expo/vector-icons';
-import constants from '../../../helpers/constants';
+import { View } from 'react-native';
+import PickFileButton from './PickFileButton.jsx';
+import PickPhotoButton from './PickPhotoButton.jsx';
+import TakePhotoButton from './TakePhotoButton.jsx';
 
 /**********************************************************/
 
@@ -15,63 +10,11 @@ export default function AddDocumentButtonsGroup(props) {
 
     const [ document, setDocument ] = useState(null);
 
-    function pickFile() {
-        return;
-    }
-    function pickPhoto() {
-        return;
-    }
-    function takePhoto() {
-        return;
-    }
-
     return (
         <View>
-            <Button
-                iconName={'insert-drive-file'}
-                onPress={pickFile}
-            />
-            <Button
-                iconName={'photo-library'}
-                onPress={pickPhoto}
-            />
-            <Button
-                iconName={'photo-camera'}
-                onPress={takePhoto}
-            />
+            <PickFileButton/>
+            <PickPhotoButton/>
+            <TakePhotoButton/>
         </View>
     );
 }
-
-function Button({ onPress, iconName, ...rest }) {
-    return (
-        <TouchableOpacity
-            style={styles.imageButton}
-            onPress={onPress}
-        >
-            <MaterialIcons
-                name={iconName}
-                size={75}
-                color={constants.highlightColor}
-            />
-        </TouchableOpacity>
-    );
-}
-
-const styles = StyleSheet.create({
-    viewportContainer: {
-        width: '100%',
-        height: '100%',
-        justifyContent: 'flex-start',
-        borderRadius: 4,
-    },
-    image: {
-        width: 125,
-        height: 125,
-        marginBottom: 4,
-        marginTop: 4,
-    },
-    buttonImageContainer: { width: '95%' },
-    imageButton: { width: '50%' },
-
-});

--- a/src/components/ConnectionsViewTabs/AddDocumentButtonsGroup/styles.js
+++ b/src/components/ConnectionsViewTabs/AddDocumentButtonsGroup/styles.js
@@ -1,5 +1,10 @@
 import { StyleSheet } from 'react-native';
 
 export default StyleSheet.create({
-    button: {},
+    button: {
+        backgroundColor: 'black',
+        color: 'white',
+        borderRadius: 25,
+        width: '30%',
+    },
 });

--- a/src/components/ConnectionsViewTabs/AddDocumentButtonsGroup/styles.js
+++ b/src/components/ConnectionsViewTabs/AddDocumentButtonsGroup/styles.js
@@ -1,10 +1,22 @@
 import { StyleSheet } from 'react-native';
+import constants from '../../../helpers/constants';
+
 
 export default StyleSheet.create({
+    buttonsGroup: {
+        display: 'flex',
+        justifyContent: 'space-evenly',
+        flexDirection: 'row',
+        padding: 4,
+        width: '100%',
+    },
     button: {
-        backgroundColor: 'black',
-        color: 'white',
-        borderRadius: 25,
-        width: '30%',
+        flexGrow: 0,
+        backgroundColor: constants.highlightColor,
+        color: constants.iconColor,
+        borderRadius: 16,
+        padding: 8,
+        margin: 4,
+        // width: '30%',
     },
 });

--- a/src/components/ConnectionsViewTabs/AddDocumentButtonsGroup/styles.js
+++ b/src/components/ConnectionsViewTabs/AddDocumentButtonsGroup/styles.js
@@ -1,0 +1,5 @@
+import { StyleSheet } from 'react-native';
+
+export default StyleSheet.create({
+    button: {},
+});

--- a/src/components/ConnectionsViewTabs/AddImage.tsx
+++ b/src/components/ConnectionsViewTabs/AddImage.tsx
@@ -55,16 +55,16 @@ const AddImage = (props) => {
     };
 
     // taking image function
-    const takeImage = async () =>{
+    const takeImage = async () => {
         const result = await ImagePicker.launchCameraAsync({
             mediaTypes: ImagePicker.MediaTypeOptions.Images,
             allowsEditing: false,
-            quality: 1
+            quality: 1,
         });
-        if (!result.cancelled){
-            setAttachment(result.uri)
+        if (!result.cancelled) {
+            setAttachment(result.uri);
         }
-    }
+    };
 
     return (
         <ScrollView

--- a/src/components/ConnectionsViewTabs/AddImage.tsx
+++ b/src/components/ConnectionsViewTabs/AddImage.tsx
@@ -52,6 +52,8 @@ const AddImage = (props) => {
         if (!result.cancelled) {
             setAttachment(result.uri);
         }
+
+        return;
     };
 
     // taking image function
@@ -61,9 +63,12 @@ const AddImage = (props) => {
             allowsEditing: false,
             quality: 1,
         });
+
         if (!result.cancelled) {
             setAttachment(result.uri);
         }
+
+        return;
     };
 
     return (

--- a/src/helpers/constants.js
+++ b/src/helpers/constants.js
@@ -6,6 +6,7 @@ export default {
     devFamilyConnectionsInterestURL:
     'https://connect-our-kids.herokuapp.com/api/family_connections_interest',
     highlightColor: '#0279AC',
+    iconColor: '#ffffff',
     fontFamily: 'futura-light',
     headerFont: 'futura-medium',
     headerHeight: 55,
@@ -16,4 +17,3 @@ export default {
     familyConnectionsURI: 'https://www.youtube.com/embed/eMivJgf7RNA',
     peopleSearchURI: 'https://www.youtube.com/embed/36OwzSMHHk8',
 };
-

--- a/src/screens/ConnectionsView.tsx
+++ b/src/screens/ConnectionsView.tsx
@@ -315,7 +315,9 @@ function ConnectionsView(props) {
                                     }}
                                 >
                                     <View style={{ justifyContent: 'center', alignItems: 'center' }}>
-                                        <AddDocumentButtonsGroup />
+                                        <AddDocumentButtonsGroup onPress={() => {
+                                            props.navigation.navigate('DocumentForm', { id: connectionData.pk });
+                                        }}/>
 
                                     </View>
                                     <View style={{ width: '100%', maxHeight: '100%' }} >

--- a/src/screens/ConnectionsView.tsx
+++ b/src/screens/ConnectionsView.tsx
@@ -47,6 +47,7 @@ import ScrollToTop from '../UI/ScrollToTop';
 import ConnectionsDetailsView from './ConnectionsDetailsView';
 import EditConnectionsForm from '../components/ConnectionsViewTabs/EditConnectionForm';
 import { Row } from 'native-base';
+import AddDocumentButtonsGroup from '../components/ConnectionsViewTabs/AddDocumentButtonsGroup';
 
 
 const placeholderImg = require('../../assets/profile_placeholder.png');
@@ -66,102 +67,8 @@ function ConnectionsView(props) {
         props.getDetails(props.navigation.getParam('connectionData').person.pk);
     }, [ props.isLoadingDocs, props.isLoadingEngagements ]);
 
-    const styles = StyleSheet.create({
-        tabs: {
-            width: '100%',
-            flexDirection: 'row',
-            justifyContent: 'center',
-            alignItems: 'center',
-            borderBottomWidth: 1,
-            borderTopRightRadius: 4,
-            borderBottomColor: '#EBEBEB',
-        },
 
-        engagementTab: {
-            width: '33.3%',
-            justifyContent: 'center',
-            alignItems: 'center',
-            height: 36,
-            fontSize: 17.5,
-            textAlign: 'center',
-        },
-
-        documentsTab: {
-            width: '33.3%',
-            justifyContent: 'center',
-            alignItems: 'center',
-            height: 36,
-            fontSize: 17.5,
-            textAlign: 'center',
-        },
-        detailsTab: {
-            width: '33.3%',
-            justifyContent: 'center',
-            alignItems: 'center',
-            height: 36,
-            fontSize: 17.5,
-            textAlign: 'center',
-        },
-        thatBlue: {
-            color: constants.highlightColor,
-        },
-
-        engagementSelected: {
-            color: 'orange',
-            borderBottomWidth: 3,
-            borderBottomColor: constants.highlightColor,
-            overflow: 'hidden',
-        },
-
-        documentsSelected: {
-            color: constants.highlightColor,
-            borderBottomWidth: 3,
-            borderBottomColor: constants.highlightColor,
-            overflow: 'hidden',
-        },
-        detailsSelected: {
-            color: constants.highlightColor,
-            borderBottomWidth: 3,
-            borderBottomColor: constants.highlightColor,
-            overflow: 'hidden',
-        },
-
-        iconLabelContainer: {
-            justifyContent: 'center',
-            alignItems: 'center',
-            marginBottom: 20,
-        },
-
-        iconContainer: {
-            height: 45,
-            width: 45,
-            borderRadius: 22.5,
-            justifyContent: 'center',
-            alignItems: 'center',
-        },
-
-        iconStyles: {
-            fontSize: 28,
-            color: constants.highlightColor,
-            width: 28,
-            height: 28,
-            marginHorizontal: 10,
-        },
-
-        iconLabel: {
-            color: '#0F6580',
-            fontSize: 12,
-        },
-        avatarName: {
-            display: 'flex',
-            justifyContent: 'center',
-            alignItems: 'center',
-            paddingBottom: '10%',
-            paddingTop: '5%',
-        },
-    });
-
-    const leftArrow: string = '\u2190';
+    // const leftArrow = '\u2190';
 
     const engagementsNoDocuments: object[] = props.engagements.filter((engagement) => engagement.data_type !== 'D');
 
@@ -408,23 +315,8 @@ function ConnectionsView(props) {
                                     }}
                                 >
                                     <View style={{ justifyContent: 'center', alignItems: 'center' }}>
-                                        <TouchableOpacity
-                                            onPress={() => {
-                                                props.navigation.navigate('DocumentForm', { id: connectionData.pk });
-                                            }}
-                                            style={{
-                                                width: 162,
-                                                height: 40,
-                                                backgroundColor: constants.highlightColor,
-                                                borderRadius: 4,
-                                                justifyContent: 'center',
-                                                alignItems: 'center',
-                                                marginTop: 18,
-                                                marginBottom: 10,
-                                            }}
-                                        >
-                                            <Text style={{ color: '#FFFFFF', fontSize: 18 }}>Add Document</Text>
-                                        </TouchableOpacity>
+                                        <AddDocumentButtonsGroup />
+
                                     </View>
                                     <View style={{ width: '100%', maxHeight: '100%' }} >
                                         {props.isLoadingDocs ? <Loader />
@@ -490,3 +382,98 @@ export default connect(
         getCaseConnections,
     },
 )(ConnectionsView);
+
+const styles = StyleSheet.create({
+    tabs: {
+        width: '100%',
+        flexDirection: 'row',
+        justifyContent: 'center',
+        alignItems: 'center',
+        borderBottomWidth: 1,
+        borderTopRightRadius: 4,
+        borderBottomColor: '#EBEBEB',
+    },
+
+    engagementTab: {
+        width: '33.3%',
+        justifyContent: 'center',
+        alignItems: 'center',
+        height: 36,
+        fontSize: 17.5,
+        textAlign: 'center',
+    },
+
+    documentsTab: {
+        width: '33.3%',
+        justifyContent: 'center',
+        alignItems: 'center',
+        height: 36,
+        fontSize: 17.5,
+        textAlign: 'center',
+    },
+    detailsTab: {
+        width: '33.3%',
+        justifyContent: 'center',
+        alignItems: 'center',
+        height: 36,
+        fontSize: 17.5,
+        textAlign: 'center',
+    },
+    thatBlue: {
+        color: constants.highlightColor,
+    },
+
+    engagementSelected: {
+        color: 'orange',
+        borderBottomWidth: 3,
+        borderBottomColor: constants.highlightColor,
+        overflow: 'hidden',
+    },
+
+    documentsSelected: {
+        color: constants.highlightColor,
+        borderBottomWidth: 3,
+        borderBottomColor: constants.highlightColor,
+        overflow: 'hidden',
+    },
+    detailsSelected: {
+        color: constants.highlightColor,
+        borderBottomWidth: 3,
+        borderBottomColor: constants.highlightColor,
+        overflow: 'hidden',
+    },
+
+    iconLabelContainer: {
+        justifyContent: 'center',
+        alignItems: 'center',
+        marginBottom: 20,
+    },
+
+    iconContainer: {
+        height: 45,
+        width: 45,
+        borderRadius: 22.5,
+        justifyContent: 'center',
+        alignItems: 'center',
+    },
+
+    iconStyles: {
+        fontSize: 28,
+        color: constants.highlightColor,
+        width: 28,
+        height: 28,
+        marginHorizontal: 10,
+    },
+
+    iconLabel: {
+        color: '#0F6580',
+        fontSize: 12,
+    },
+    avatarName: {
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+        paddingBottom: '10%',
+        paddingTop: '5%',
+    },
+});

--- a/src/screens/ConnectionsView.tsx
+++ b/src/screens/ConnectionsView.tsx
@@ -315,8 +315,8 @@ function ConnectionsView(props) {
                                     }}
                                 >
                                     <View style={{ justifyContent: 'center', alignItems: 'center' }}>
-                                        <AddDocumentButtonsGroup onPress={() => {
-                                            props.navigation.navigate('DocumentForm', { id: connectionData.pk });
+                                        <AddDocumentButtonsGroup afterAccept={(uri) => {
+                                            props.navigation.navigate('DocumentForm', { id: connectionData.pk, uri });
                                         }}/>
 
                                     </View>


### PR DESCRIPTION
### Summary ###

- `AddDocumentButtonsGroup` component (and children)

    - Create new buttons group so the user can quickly pick a file, pick a photo, or take a photo and attach it to a case.
    - After the user picks an attachment, they see a form `AddDocForm` (already existed) to add details.

- `AddDocForm` component

    - Update to accept `uri` of documents.
    - Remove redundant photo picker inside `AddDocForm`.
    - Remove "sensitive info" toggle. The code still exists, but it was not being used.

### Notes ###

We used the existing navigation structure.

### Future Work ###

- MIME types

    - Properly handle different document types when `POST`ing to backend. _Everything_ is currently sent as an image.
    - Properly handle different document types when displaying the list. _Everything_ is currently displayed and opened as if it was an image.