### PR TITLE
setup code coverage

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,10 +1,53 @@
+/***********************************************************
+  jest.config
+***********************************************************/
+
 module.exports = {
-    'preset': 'jest-expo',
-    'moduleFileExtensions': [ 'json', 'js', 'jsx', 'ts', 'tsx' ],
+
+    /*
+    Limit testing to...
+    */
+    'projects': [
+        /* Android */
+        {
+            'preset': 'jest-expo/android',
+        },
+        /* iOS */
+        {
+            'preset': 'jest-expo/ios',
+        },
+    ],
+    /*
+    DO test...
+    */
+    'moduleFileExtensions': [
+        /* JSON files (*.json) */
+        'json',
+        /* JavaScript files (*.{js, jsx}) */
+        'js',
+        'jsx',
+        /* TypeScript files (*.{ts, tsx}) */
+        'ts',
+        'tsx',
+    ],
+    /*
+    DO transform...
+    */
     'transform': {
-        '^.+\\.[t|j]sx?$': 'babel-jest',
+        /* JavaScript files (*.{js, jsx}) */
+        '^.+\\.js[x]?$': 'babel-jest',
+        /* TypeScript files (*.{ts, tsx}) */
+        '^.+\\.ts[x]?$': 'babel-jest',
     },
+    /*
+    DO NOT transform...
+    */
     'transformIgnorePatterns': [
+        /*
+        Files as directed by Expo.
+        source: <https://docs.expo.io/versions/latest/guides/testing-with-jest/#jest-configuration>
+        */
         'node_modules/(?!(jest-)?react-native|react-clone-referenced-element|@react-native-community|expo(nent)?|@expo(nent)?/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base)',
     ],
+
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -10,26 +10,33 @@ module.exports = {
 
     /* Limit testing to... */
     'projects': [
+
         /* Android */
         {
             'preset': 'jest-expo/android',
         },
+
         /* iOS */
         {
             'preset': 'jest-expo/ios',
         },
+
     ],
 
     /* DO test... */
     'moduleFileExtensions': [
-        /* JSON files (*.json) */
+
+        /* JSON */
         'json',
-        /* JavaScript files (*.{js, jsx}) */
+
+        /* JavaScript */
         'js',
         'jsx',
-        /* TypeScript files (*.{ts, tsx}) */
+
+        /* TypeScript */
         'ts',
         'tsx',
+
     ],
 
     /***************************************
@@ -38,19 +45,26 @@ module.exports = {
 
     /* DO transform... */
     'transform': {
-        /* JavaScript files (*.{js, jsx}) */
+
+        /* JavaScript */
         '^.+\\.js[x]?$': 'babel-jest',
-        /* TypeScript files (*.{ts, tsx}) */
+
+        /* TypeScript */
         '^.+\\.ts[x]?$': 'babel-jest',
+
     },
 
     /* DO NOT transform... */
     'transformIgnorePatterns': [
+
         /*
-        Files as directed by Expo.
+        ... as directed by Expo
         source: <https://docs.expo.io/versions/latest/guides/testing-with-jest/#jest-configuration>
         */
         'node_modules/(?!(jest-)?react-native|react-clone-referenced-element|@react-native-community|expo(nent)?|@expo(nent)?/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base)',
+
     ],
+
+    /**************************************/
 
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,9 +4,7 @@
 
 module.exports = {
 
-    /*
-    Limit testing to...
-    */
+    /* Limit testing to... */
     'projects': [
         /* Android */
         {
@@ -17,9 +15,8 @@ module.exports = {
             'preset': 'jest-expo/ios',
         },
     ],
-    /*
-    DO test...
-    */
+
+    /* DO test... */
     'moduleFileExtensions': [
         /* JSON files (*.json) */
         'json',
@@ -30,18 +27,16 @@ module.exports = {
         'ts',
         'tsx',
     ],
-    /*
-    DO transform...
-    */
+
+    /* DO transform... */
     'transform': {
         /* JavaScript files (*.{js, jsx}) */
         '^.+\\.js[x]?$': 'babel-jest',
         /* TypeScript files (*.{ts, tsx}) */
         '^.+\\.ts[x]?$': 'babel-jest',
     },
-    /*
-    DO NOT transform...
-    */
+
+    /* DO NOT transform... */
     'transformIgnorePatterns': [
         /*
         Files as directed by Expo.

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,6 +4,10 @@
 
 module.exports = {
 
+    /***************************************
+        WHAT TO TEST
+    ***************************************/
+
     /* Limit testing to... */
     'projects': [
         /* Android */
@@ -27,6 +31,10 @@ module.exports = {
         'ts',
         'tsx',
     ],
+
+    /***************************************
+        CODE TRANSFORMATION (transpilation)
+    ***************************************/
 
     /* DO transform... */
     'transform': {

--- a/jest.config.js
+++ b/jest.config.js
@@ -65,6 +65,38 @@ module.exports = {
 
     ],
 
+    /***************************************
+        CODE COVERAGE
+    ***************************************/
+
+    /* DO NOT collect (by default) */
+    'collectCoverage': false,
+
+    /* DO count files matching... */
+    'collectCoverageFrom': [
+
+        /* JavaScript files */
+        '**/*.{js,jsx}',
+
+        /* TypeScript files */
+        '**/*.{ts,tsx}',
+
+        /* --- EXCLUDING --- */
+
+        /* dependencies */
+        '!**/*_modules/**',
+        '!**/*_packages/**',
+
+        /* configuration files */
+        '!**/.*rc.{js,ts}',
+        '!**/*.config.{js,ts}',
+        '!**/*.setup.{js,ts}',
+
+        /* builds */
+        '!<rootDir>/build/**',
+
+    ],
+
     /**************************************/
 
 };

--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
     "web": "expo start --web",
     "eject": "expo eject",
     "lint": "eslint ./src || true",
-    "test": "jest --watchAll"
+    "test": "jest --watch --changedSince=origin/master",
+    "test:debug": "jest --watch --onlyChanged --runInBand",
+    "test:coverage": "jest --coverage=true",
+    "test:update-snapshots": "jest --updateSnapshot"
   },
   "dependencies": {
     "@react-native-community/datetimepicker": "2.1.0",


### PR DESCRIPTION
### Summary

Add configuration for code coverage via `jest`.

### Affects

- Add explanatory comments to `jest.config.js`.
- Update `jest` config so it only runs tests for Android and iOS.
- Add code coverage to `jest` config.
- Update test-related scripts:

    - `test`: in watch mode, run tests for all changes since `origin/master`
    - `test:debug`: in watch mode, run tests for all changes since previous test
    - `test:coverage`: run all tests once and save code coverage stats
    - `test:update-snapshots`: update snapshots