### PR TITLE
added option for Case File Number to display if fullName not available

### DIFF
--- a/src/screens/CaseScreen.tsx
+++ b/src/screens/CaseScreen.tsx
@@ -50,7 +50,6 @@ import {
     deleteRelationshipMutationVariables,
 } from '../generated/deleteRelationshipMutation';
 import { Roles } from '../generated/globalTypes';
-import { parentPort } from 'worker_threads';
 
 interface StateProps {
     caseId: number;

--- a/src/screens/CaseScreen.tsx
+++ b/src/screens/CaseScreen.tsx
@@ -50,6 +50,7 @@ import {
     deleteRelationshipMutationVariables,
 } from '../generated/deleteRelationshipMutation';
 import { Roles } from '../generated/globalTypes';
+import { parentPort } from 'worker_threads';
 
 interface StateProps {
     caseId: number;
@@ -89,7 +90,12 @@ let relationshipsListViewRef2: SwipeListView<
 const DetailsView = (props: { case?: caseDetailFull }): JSX.Element =>
     props.case?.details ? (
         <ListItem
-            title={props.case.details?.person.fullName}
+            title={
+                props.case.details.person.fullName ||
+                (props.case.details.caseFileNumber
+                    ? 'Case ' + props.case.details.caseFileNumber
+                    : '')
+            }
             titleStyle={{ fontSize: 18 }}
             subtitle={
                 <View>

--- a/src/screens/FamilyConnectionsScreen.tsx
+++ b/src/screens/FamilyConnectionsScreen.tsx
@@ -320,7 +320,12 @@ const FamilyConnectionsScreen = (props: Props): JSX.Element => {
         <View>
             <ListItem
                 key={itemInfo.index}
-                title={itemInfo.item.person.fullName}
+                title={
+                    itemInfo.item.person.fullName ||
+                    (itemInfo.item.caseFileNumber
+                        ? 'Case ' + itemInfo.item.caseFileNumber
+                        : '')
+                }
                 titleStyle={{ color: '#5A6064' }}
                 subtitle={createPersonSubtitle(itemInfo.item.person)}
                 subtitleStyle={{ color: '#9FABB3' }}


### PR DESCRIPTION
https://trello.com/c/RF58ztQo/412-cases-without-child-name-using-case-number-not-showing-title-in-mobile-app

If the child's fullName doesn't exist, the caseFileNumber will now display.

<img src="https://user-images.githubusercontent.com/22917212/94475473-1f351d80-019d-11eb-9958-9c65e4b76792.PNG" width="250" alt="some_text"><img src="https://user-images.githubusercontent.com/22917212/94475463-1cd2c380-019d-11eb-9f1f-f3c1b603a702.PNG" width="250" alt="some_text">
